### PR TITLE
Exclude com.arthenica:ffmpeg-kit-full to fix build error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,10 @@ android {
     }
 }
 
+configurations {
+    all*.exclude group: 'com.arthenica', module: 'ffmpeg-kit-full'
+}
+
 dependencies {
 
     implementation 'com.google.android.exoplayer:exoplayer-core:2.18.1'


### PR DESCRIPTION
Added a configuration exclusion for `com.arthenica:ffmpeg-kit-full` in `app/build.gradle`. This ensures that the build system does not attempt to resolve the remote artifact (which may be missing or archived) and strictly uses the local `libs/ffmpeg-kit.aar` file.