### PR TITLE
Add CI and per-ABI signed release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+    tags-ignore: ['**']
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
+      - run: chmod +x gradlew
+      - name: Assemble debug
+        run: ./gradlew assembleDebug
+      - name: Lint
+        run: ./gradlew lintDebug
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-${{ github.sha }}
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-report-${{ github.sha }}
+          path: app/build/reports/lint-results-debug.*
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
       - name: Assemble debug
         run: ./gradlew assembleDebug
@@ -28,7 +28,7 @@ jobs:
       - name: Unit tests
         run: ./gradlew testDebugUnitTest
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: app-debug-${{ github.sha }}
           path: app/build/outputs/apk/debug/*.apk
@@ -36,7 +36,7 @@ jobs:
           retention-days: 14
       - name: Upload lint report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lint-report-${{ github.sha }}
           path: app/build/reports/lint-results-debug.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
       - run: chmod +x gradlew
       - name: Assemble debug
         run: ./gradlew assembleDebug
@@ -28,7 +28,7 @@ jobs:
       - name: Unit tests
         run: ./gradlew testDebugUnitTest
       - name: Upload debug APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug-${{ github.sha }}
           path: app/build/outputs/apk/debug/*.apk
@@ -36,7 +36,7 @@ jobs:
           retention-days: 14
       - name: Upload lint report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: lint-report-${{ github.sha }}
           path: app/build/reports/lint-results-debug.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release APK
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Verify tag matches app versionName
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          app_version=$(sed -nE 's/.*versionName[[:space:]]*"([^"]+)".*/\1/p' app/build.gradle | head -1)
+          if [ -z "$app_version" ]; then
+            echo "Could not parse versionName from app/build.gradle" >&2
+            exit 1
+          fi
+          if [ "$tag_version" != "$app_version" ]; then
+            echo "Tag $GITHUB_REF_NAME (=> $tag_version) does not match app versionName ($app_version)" >&2
+            exit 1
+          fi
+          echo "Tag matches versionName: $app_version"
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
+      - run: chmod +x gradlew && ./gradlew assembleRelease
+      - uses: r0adkll/sign-android-release@v1
+        id: sign
+        env:
+          BUILD_TOOLS_VERSION: '34.0.0'
+        with:
+          releaseDirectory: app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+      - name: Rename signed APKs
+        run: |
+          mkdir -p release-artifacts
+          for apk in app/build/outputs/apk/release/app-*-release-unsigned-signed.apk; do
+            [ -f "$apk" ] || continue
+            name=$(basename "$apk")
+            arch=$(printf '%s' "$name" | sed -E 's/^app-(.+)-release-unsigned-signed\.apk$/\1/')
+            cp "$apk" "release-artifacts/LibreCuts-${arch}.apk"
+          done
+          ls -lh release-artifacts/
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: release-artifacts/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Verify tag matches app versionName
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
@@ -30,7 +30,7 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
       - run: chmod +x gradlew && ./gradlew assembleRelease
       - uses: r0adkll/sign-android-release@v1
         id: sign
@@ -52,6 +52,6 @@ jobs:
             cp "$apk" "release-artifacts/LibreCuts-${arch}.apk"
           done
           ls -lh release-artifacts/
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: release-artifacts/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
             exit 1
           fi
           echo "Tag matches versionName: $app_version"
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew && ./gradlew assembleRelease
       - uses: r0adkll/sign-android-release@v1
         id: sign

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,12 @@ misc.xml
 deploymentTargetDropDown.xml
 render.experimental.xml
 
+# VS Code
+*.code-workspace
+
 # Keystore files
 *.jks
+*.jks.b64
 *.keystore
 
 # Google Services (e.g. APIs or Firebase)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,15 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'armeabi-v7a', 'arm64-v8a', 'x86_64'
+            universalApk false
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
**Changes**:
- Add `ci.yml`: debug build, lint, and unit tests on every push/PR with artifact upload.
- Add `release.yml`: `v*` tag-triggered per-ABI signed APK build, published as `LibreCuts-<arch>.apk`, with a guard verifying the tag matches `versionName`.
- Enable `splits { abi }` in `app/build.gradle` to produce per-architecture APKs.
- Ignore `*.jks.b64` and `*.code-workspace`.

**Observations**:
- Per-ABI builds are _way_ better than a whole, fat apk file for all. The name split in the workflow is also accounted for [Obtainium](https://github.com/ImranR98/Obtainium), so it should automatically pick the right architecture for a user's device.
- Workflow was partially aided by Claude (or, if you _really_ have to: "vibecoded"), though it was proofread and verified by me. Any mistakes are mine alone.
- I'd delete and add `build_log.txt` to `.gitignore` if I were you. That must be unintended.