### PR TITLE
Fix release workflow guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Verify tag matches app versionName
+        if: github.ref_type == 'tag'
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
           app_version=$(sed -nE 's/.*versionName[[:space:]]*"([^"]+)".*/\1/p' app/build.gradle | head -1)
@@ -53,5 +54,6 @@ jobs:
           done
           ls -lh release-artifacts/
       - uses: softprops/action-gh-release@v3
+        if: github.ref_type == 'tag'
         with:
           files: release-artifacts/*.apk

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ render.experimental.xml
 
 # VS Code
 *.code-workspace
+.claude/
 
 # Keystore files
 *.jks


### PR DESCRIPTION
The versionName guard and release publish step assumed a tag ref, but workflow_dispatch runs against a branch ref (e.g. main), failing the guard with "Tag main (=> main) does not match app versionName". Gate both steps on tag refs so manual dispatch builds without publishing, while tag pushes still enforce the versionName match.

Addresses #17.

Oh, also gitignores `.claude/`.