### PR TITLE
fix: apply keyframed opacity to draggable overlay previews

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-26T08:03:40.419914+00:00",
+  "commits_behind_before_sync": 0,
+  "action_taken": "noop"
+}

--- a/app/src/androidTest/java/com/tharunbirla/librecuts/customviews/KeyframeOpacityPreviewTest.kt
+++ b/app/src/androidTest/java/com/tharunbirla/librecuts/customviews/KeyframeOpacityPreviewTest.kt
@@ -1,0 +1,110 @@
+package com.tharunbirla.librecuts.customviews
+
+import android.graphics.Color
+import android.widget.EditText
+import android.widget.ImageView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KeyframeOpacityPreviewTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = instrumentation.targetContext
+
+    @Test
+    fun setPropertiesAppliesMidpointOpacityToImageAndTextPreviews() {
+        instrumentation.runOnMainSync {
+            val imageOverlay = DraggableImageOverlayView(context)
+            val image = imageOverlay.getChildAt(0) as ImageView
+            imageOverlay.setProperties(0.5f, 0.5f, 0.3f, 0.3f, 0f, 0.5f, false)
+
+            assertEquals(0.5f, imageOverlay.getOpacity(), FLOAT_DELTA)
+            assertEquals(0.5f, image.alpha, FLOAT_DELTA)
+
+            val textOverlay = DraggableTextOverlayView(context)
+            val text = textOverlay.getChildAt(0) as EditText
+            textOverlay.setTextColor("#336699")
+            textOverlay.setProperties(0.5f, 0.5f, 0.5f)
+
+            assertEquals(0.5f, textOverlay.getOpacity(), FLOAT_DELTA)
+            assertEquals(127, Color.alpha(text.currentTextColor))
+            assertEquals(0x33, Color.red(text.currentTextColor))
+            assertEquals(0x66, Color.green(text.currentTextColor))
+            assertEquals(0x99, Color.blue(text.currentTextColor))
+        }
+    }
+
+    @Test
+    fun setPropertiesAppliesFullyTransparentAndOpaqueEndpoints() {
+        instrumentation.runOnMainSync {
+            val imageOverlay = DraggableImageOverlayView(context)
+            val image = imageOverlay.getChildAt(0) as ImageView
+            val textOverlay = DraggableTextOverlayView(context)
+            val text = textOverlay.getChildAt(0) as EditText
+
+            imageOverlay.setProperties(0.5f, 0.5f, 0.3f, 0.3f, 0f, 0f, false)
+            textOverlay.setProperties(0.5f, 0.5f, 0f)
+
+            assertEquals(0f, image.alpha, FLOAT_DELTA)
+            assertEquals(0, Color.alpha(text.currentTextColor))
+
+            imageOverlay.setProperties(0.5f, 0.5f, 0.3f, 0.3f, 0f, 1f, false)
+            textOverlay.setProperties(0.5f, 0.5f, 1f)
+
+            assertEquals(1f, image.alpha, FLOAT_DELTA)
+            assertEquals(255, Color.alpha(text.currentTextColor))
+        }
+    }
+
+    @Test
+    fun repeatedPositionUpdatesKeepSuppliedOpacityVisible() {
+        instrumentation.runOnMainSync {
+            val imageOverlay = DraggableImageOverlayView(context)
+            val image = imageOverlay.getChildAt(0) as ImageView
+            val textOverlay = DraggableTextOverlayView(context)
+            val text = textOverlay.getChildAt(0) as EditText
+
+            imageOverlay.setProperties(0.25f, 0.25f, 0.3f, 0.3f, 0f, 0.4f, false)
+            textOverlay.setProperties(0.25f, 0.25f, 0.4f)
+            imageOverlay.setProperties(0.75f, 0.75f, 0.3f, 0.3f, 0f, 0.4f, false)
+            textOverlay.setProperties(0.75f, 0.75f, 0.4f)
+
+            assertEquals(0.4f, image.alpha, FLOAT_DELTA)
+            assertEquals((0.4f * 255).toInt(), Color.alpha(text.currentTextColor))
+        }
+    }
+
+    @Test
+    fun imageOpacityCanBeAppliedBeforeMediaLoads() {
+        instrumentation.runOnMainSync {
+            val imageOverlay = DraggableImageOverlayView(context)
+            val image = imageOverlay.getChildAt(0) as ImageView
+
+            imageOverlay.setProperties(0.5f, 0.5f, 0.3f, 0.3f, 0f, 0.25f, false)
+
+            assertEquals(0.25f, imageOverlay.getOpacity(), FLOAT_DELTA)
+            assertEquals(0.25f, image.alpha, FLOAT_DELTA)
+        }
+    }
+
+    @Test
+    fun invalidTextColorKeepsFallbackWhenOpacityIsApplied() {
+        instrumentation.runOnMainSync {
+            val textOverlay = DraggableTextOverlayView(context)
+            val text = textOverlay.getChildAt(0) as EditText
+            textOverlay.setTextColor("not-a-color")
+
+            textOverlay.setProperties(0.5f, 0.5f, 0.5f)
+
+            assertEquals(0.5f, textOverlay.getOpacity(), FLOAT_DELTA)
+            assertEquals(Color.WHITE, text.currentTextColor)
+        }
+    }
+
+    private companion object {
+        const val FLOAT_DELTA = 0.0001f
+    }
+}

--- a/app/src/main/java/com/tharunbirla/librecuts/customviews/DraggableImageOverlayView.kt
+++ b/app/src/main/java/com/tharunbirla/librecuts/customviews/DraggableImageOverlayView.kt
@@ -845,7 +845,7 @@ class DraggableImageOverlayView @JvmOverloads constructor(
         relativeWidth = rw
         relativeHeight = rh
         rotationAngle = rot
-        opacity = op
+        setOpacity(op)
         isMirrored = mir
         updateImageViewSizeAndPosition()
     }

--- a/app/src/main/java/com/tharunbirla/librecuts/customviews/DraggableTextOverlayView.kt
+++ b/app/src/main/java/com/tharunbirla/librecuts/customviews/DraggableTextOverlayView.kt
@@ -585,7 +585,7 @@ class DraggableTextOverlayView @JvmOverloads constructor(
     fun setProperties(rx: Float, ry: Float, op: Float) {
         relativeX = rx
         relativeY = ry
-        currentOpacity = op
+        setOpacity(op)
         post {
             positionEditTextFromRelative()
             invalidate()


### PR DESCRIPTION
Make each draggable overlay's bulk property update apply opacity through the same visual update path as its dedicated `setOpacity(...)` method, preserving the existing `VideoEditingActivity` interpolation and slider wiring. Issue #58 combines future keyframe feature requests with a reproducible bug: changing an image or text overlay's opacity keyframe does not make the selected overlay transparent in the editor preview.

Happy path: applying a `0.5` opacity through `setProperties(...)` makes an image overlay's rendered child alpha `0.5` and gives a text overlay's displayed text a 50% alpha while retaining its RGB color; Timeline integration: two opacity keyframes at `1.0` and `0.0` produce the interpolated midpoint in `VideoEditingActivity`, and the bulk update path visibly applies that midpoint to the selected image and text overlays during a seek or playback update.

Closes #58
