### PR TITLE
chore: remove stray .osc-metadata/sync.json

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,5 +1,0 @@
-{
-  "fork_synced_at": "2026-07-26T08:03:40.419914+00:00",
-  "commits_behind_before_sync": 0,
-  "action_taken": "noop"
-}


### PR DESCRIPTION
## Summary

Removes `.osc-metadata/sync.json`, which I committed by accident in #59.

## Why

That file is local bookkeeping from my own contribution tooling (it records
when I last synced my fork). It has no relationship to LibreCuts and should
never have been tracked in this repository. I caught it in a post-merge audit
of my own PRs. Apologies for the noise.

The deletion is the whole change; nothing else is touched.
