### PR TITLE
Fix #86: Remove ACCESS_NETWORK_STATE permission injected by ExoPlayer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <!-- Remove network permission injected by ExoPlayer dependency -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" tools:node="remove" />
+
     <application
         android:name=".LibreCutsApplication"
         android:allowBackup="true"


### PR DESCRIPTION
Explicitly remove android.permission.ACCESS_NETWORK_STATE using tools:node="remove" in AndroidManifest.xml to prevent ExoPlayer core dependency from injecting network permissions into the merged manifest.